### PR TITLE
ENH: Adding action for execution of virsorter2 run command

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ cd q2-viromics
 Then, run:
 
 ```shell
-mamba create -n q2-viromics -c conda-forge -c bioconda -c  https://packages.qiime2.org/qiime2/2023.5/tested/ -c defaults q2-types numpy=1.23.5 q2cli virsorter=2 "python=3.8" scikit-learn=0.22.1 pandas seaborn hmmer==3.3 prodigal=2.6 screed=1 ruamel.yaml click pip last ncbi-genome-download checkv pyhmmer
+mamba create -n q2-viromics -c conda-forge -c bioconda -c  https://packages.qiime2.org/qiime2/2023.5/staged/core/ -c defaults q2-types numpy=1.23.5 q2cli virsorter=2 "python=3.8" scikit-learn=0.22.1 pandas seaborn hmmer==3.3 prodigal=2.6 screed=1 ruamel.yaml click pip last ncbi-genome-download checkv pyhmmer
 ```
 
 After this completes, activate the new environment you created by running:

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ cd q2-viromics
 Then, run:
 
 ```shell
-mamba create -n q2-viromics -c conda-forge -c bioconda -c  https://packages.qiime2.org/qiime2/2023.5/tested/ -c defaults q2-types numpy=1.23.5 q2cli virsorter=2 "python=3.8" scikit-learn=0.22.1 pandas seaborn hmmer==3.3 prodigal=2.6 screed=1 ruamel.yaml click pip last ncbi-genome-download checkv pyhmmer
+mamba create -n q2-viromics-qiime2024.2 -c conda-forge -c bioconda -c https://packages.qiime2.org/qiime2/2024.2/shotgun/released/  -c defaults q2-types q2cli virsorter=2 "python=3.8" scikit-learn=0.22.1 pandas seaborn hmmer==3.3 prodigal=2.6 screed=1 ruamel.yaml click pip last ncbi-genome-download checkv pyhmmer
 ```
 
 After this completes, activate the new environment you created by running:
@@ -42,18 +42,3 @@ make install
 make dev
 qiime dev refresh-cache
 ```
-
-<!---
-## About
-
-The `q2-viromics` Python package was [created from template](https://develop.qiime2.org/en/latest/plugins/tutorials/create-from-template.html).
-To learn more about `q2-viromics`, refer to the [project website](https://example.com).
-To learn how to use QIIME 2, refer to the [QIIME 2 User Documentation](https://docs.qiime2.org).
-To learn QIIME 2 plugin development, refer to [*Developing with QIIME 2*](https://develop.qiime2.org).
-
-`q2-viromics` is a QIIME 2 community plugin, meaning that it is not necessarily developed and maintained by the developers of QIIME 2.
-Please be aware that because community plugins are developed by the QIIME 2 developer community, and not necessarily the QIIME 2 developers themselves, some may not be actively maintained or compatible with current release versions of the QIIME 2 distributions.
-More information on development and support for community plugins can be found [here](https://library.qiime2.org).
-If you need help with a community plugin, first refer to the [project website](https://example.com).
-If that page doesn't provide information on how to get help, or you need additional help, head to the [Community Plugins category](https://forum.qiime2.org/c/community-contributions/community-plugins/14) on the QIIME 2 Forum where the QIIME 2 developers will do their best to help you.
--->

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ cd q2-viromics
 Then, run:
 
 ```shell
-mamba create -n q2-viromics-qiime2024.2 -c conda-forge -c bioconda -c https://packages.qiime2.org/qiime2/2024.2/shotgun/released/  -c defaults q2-types q2cli virsorter=2 "python=3.8" scikit-learn=0.22.1 pandas seaborn hmmer==3.3 prodigal=2.6 screed=1 ruamel.yaml click pip last ncbi-genome-download checkv pyhmmer
+mamba create -n q2-viromics -c conda-forge -c bioconda -c https://packages.qiime2.org/qiime2/2024.2/shotgun/released/  -c defaults q2-types q2cli virsorter=2 "python=3.8" scikit-learn=0.22.1 pandas seaborn hmmer==3.3 prodigal=2.6 screed=1 ruamel.yaml click pip last ncbi-genome-download checkv pyhmmer
 ```
 
 After this completes, activate the new environment you created by running:

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ cd q2-viromics
 Then, run:
 
 ```shell
-mamba create -n q2-viromics -c conda-forge -c bioconda -c https://packages.qiime2.org/qiime2/2024.2/shotgun/released/  -c defaults q2-types q2cli virsorter=2 "python=3.8" scikit-learn=0.22.1 pandas seaborn hmmer==3.3 prodigal=2.6 screed=1 ruamel.yaml click pip last ncbi-genome-download checkv pyhmmer
+mamba create -n q2-viromics -c conda-forge -c bioconda -c  https://packages.qiime2.org/qiime2/2023.5/tested/ -c defaults q2-types numpy=1.23.5 q2cli virsorter=2 "python=3.8" scikit-learn=0.22.1 pandas seaborn hmmer==3.3 prodigal=2.6 screed=1 ruamel.yaml click pip last ncbi-genome-download checkv pyhmmer
 ```
 
 After this completes, activate the new environment you created by running:

--- a/q2_viromics/plugin_setup.py
+++ b/q2_viromics/plugin_setup.py
@@ -48,19 +48,19 @@ plugin.register_semantic_types(Virsorter2Db, ViralScore)
 plugin.register_artifact_class(
     Virsorter2Db,
     directory_format=Virsorter2DbDirFmt,
-    description=("Represents a VirSorter2 database."),
+    description=("VirSorter2 database."),
 )
 
 plugin.register_artifact_class(
     FeatureData[ViralScore],
     directory_format=ViralScoreDirFmt,
-    description=("Represents viral score table from VirSorter2."),
+    description=("Viral score table from VirSorter2."),
 )
 
 plugin.register_artifact_class(
     FeatureData[ViralBoundary],
     directory_format=ViralBoundaryDirFmt,
-    description=("Represents viral boundary table from VirSorter2."),
+    description=("Viral boundary table from VirSorter2."),
 )
 
 

--- a/q2_viromics/plugin_setup.py
+++ b/q2_viromics/plugin_setup.py
@@ -6,12 +6,22 @@
 # The full license is in the file LICENSE, distributed with this software.
 # ----------------------------------------------------------------------------
 
+import importlib
+
+from q2_types.feature_data import FeatureData, Sequence
 from qiime2.plugin import Citations, Int, Plugin, Range
 
 from q2_viromics import __version__
-from q2_viromics.types._format import Virsorter2DbDirFmt
-from q2_viromics.types._type import Virsorter2Db
+from q2_viromics.types._format import (
+    ViralBoundaryDirFmt,
+    ViralBoundaryFmt,
+    ViralScoreDirFmt,
+    ViralScoreFmt,
+    Virsorter2DbDirFmt,
+)
+from q2_viromics.types._type import ViralBoundary, ViralScore, Virsorter2Db
 from q2_viromics.virsorter2_fetch_db import virsorter2_fetch_db
+from q2_viromics.virsorter2_run import _virsorter2_analysis, virsorter2_run
 
 citations = Citations.load("citations.bib", package="q2_viromics")
 
@@ -27,14 +37,32 @@ plugin = Plugin(
 
 plugin.register_formats(
     Virsorter2DbDirFmt,
+    ViralScoreFmt,
+    ViralScoreDirFmt,
+    ViralBoundaryFmt,
+    ViralBoundaryDirFmt,
 )
-plugin.register_semantic_types(Virsorter2Db)
+
+plugin.register_semantic_types(Virsorter2Db, ViralScore)
 
 plugin.register_artifact_class(
     Virsorter2Db,
     directory_format=Virsorter2DbDirFmt,
-    description=("Represents a group Virsorter2 database."),
+    description=("Represents a VirSorter2 database."),
 )
+
+plugin.register_artifact_class(
+    FeatureData[ViralScore],
+    directory_format=ViralScoreDirFmt,
+    description=("Represents viral score table from VirSorter2."),
+)
+
+plugin.register_artifact_class(
+    FeatureData[ViralBoundary],
+    directory_format=ViralBoundaryDirFmt,
+    description=("Represents viral boundary table from VirSorter2."),
+)
+
 
 plugin.methods.register_function(
     function=virsorter2_fetch_db,
@@ -55,3 +83,68 @@ plugin.methods.register_function(
     ),
     citations=[],
 )
+
+
+plugin.pipelines.register_function(
+    function=virsorter2_run,
+    inputs={
+        "sequences": FeatureData[Sequence],
+        "database": Virsorter2Db,
+    },
+    parameters={"n_jobs": Int % Range(1, None)},
+    input_descriptions={
+        "sequences": "Input sequences from an assembly or genome "
+        "data for virus detection.",
+        "database": "VirSorter2 database.",
+    },
+    parameter_descriptions={
+        "n_jobs": "Max number of jobs allowed in parallel.",
+    },
+    outputs=[
+        ("viral_sequences", FeatureData[Sequence]),
+        ("viral_score", FeatureData[ViralScore]),
+        ("viral_boundary", FeatureData[ViralBoundary]),
+    ],
+    output_descriptions={
+        "viral_sequences": "Identified viral sequences.",
+        "viral_score": "Viral score table.",
+        "viral_boundary": "Viral boundary table.",
+    },
+    name="Identifying and vizualize statistics for viral sequences.",
+    description="Performs analysis for identifying and categorizing viral "
+    "sequences from metagenomic data using VirSorter2 and provides "
+    "useful visualizations.",
+    citations=[],
+)
+
+plugin.methods.register_function(
+    function=_virsorter2_analysis,
+    inputs={
+        "sequences": FeatureData[Sequence],
+        "database": Virsorter2Db,
+    },
+    parameters={"n_jobs": Int % Range(1, None)},
+    input_descriptions={
+        "sequences": "Input sequences from an assembly or genome "
+        "data for virus detection.",
+        "database": "VirSorter2 database.",
+    },
+    parameter_descriptions={"n_jobs": "Max number of jobs allowed in parallel."},
+    outputs=[
+        ("viral_sequences", FeatureData[Sequence]),
+        ("viral_score", FeatureData[ViralScore]),
+        ("viral_boundary", FeatureData[ViralBoundary]),
+    ],
+    output_descriptions={
+        "viral_sequences": "Identified viral sequences.",
+        "viral_score": "Viral score table.",
+        "viral_boundary": "Viral boundary table.",
+    },
+    name="Identifying and vizualize statistics for viral sequences.",
+    description="Performs analysis for identifying and categorizing viral "
+    "sequences from metagenomic data using VirSorter2 and provides "
+    "useful visualizations.",
+    citations=[],
+)
+
+importlib.import_module("q2_viromics.types._transformer")

--- a/q2_viromics/tests/data/type/vs2_out/final-viral-boundary.tsv
+++ b/q2_viromics/tests/data/type/vs2_out/final-viral-boundary.tsv
@@ -1,0 +1,8 @@
+seqname	trim_orf_index_start	trim_orf_index_end	trim_bp_start	trim_bp_end	trim_pr	trim_pr_max	prox_orf_index_start	prox_orf_index_end	prox_bp_start	prox_bp_end	prox_pr	prox_pr_max	partial	full_orf_index_start	full_orf_index_end	full_bp_start	full_bp_end	pr_full	arc	bac	euk	vir	mix	unaligned	hallmark_cnt	group	shape	seqname_new	final_max_score	final_max_score_group
+ssDNA-linear	1	2	290	4547	0.927	0.927	1	2	290	4547			0	1	2	290	4547	0.927	0.0	0.0	0.0	100.0	0.0	0.0	0	ssDNA	linear	ssDNA-linear||full	0.927	ssDNA
+lavidaviridae-linear	1	9	1	8598	0.993	0.993	1	9	1	8598			0	1	9	1	8598	0.993	0.0	0.0	0.0	44.4	0.0	55.6	1	dsDNAphage	linear	lavidaviridae-linear||full	0.993	dsDNAphage
+RNA-linear	1	5	3	5540	0.5	0.5	1	5	3	5540			0	1	5	3	5540	0.5	0.0	0.0	0.0	20.0	20.0	60.0	0	dsDNAphage	linear	RNA-linear||full	0.5	dsDNAphage
+NCLDV-linear	1	1008	3	1181113	0.833	0.847	1	1008	3	1181113			0	1	1008	3	1181113	0.833	0.0	1.5	3.8	53.7	21.6	19.4	9	dsDNAphage	linear	NCLDV-linear||full	0.833	dsDNAphage
+Caudo-linear	1	14	1	13841	1.0	1.0	1	14	1	13841			0	1	14	1	13841	1.0	0.0	0.0	0.0	85.7	0.0	14.3	12	dsDNAphage	linear	Caudo-linear||full	1.0	dsDNAphage
+Caudo-circular	2	46	327	32076	0.993	0.993	2	46	327	32076			0	2	46	327	32076	0.993	0.0	0.0	0.0	77.8	0.0	22.2	4	dsDNAphage	circular	Caudo-circular||full	0.993	dsDNAphage
+Caudo-provirus	103	142	95069	133274	0.893	0.927	103	142	95069	133274	0.893	0.973	1	1	228	1	213841	0.473	3.8	11.5	0.0	26.9	36.5	21.2	12	dsDNAphage	linear	Caudo-provirus||0_partial	0.893	dsDNAphage

--- a/q2_viromics/tests/data/type/vs2_out/final-viral-score.tsv
+++ b/q2_viromics/tests/data/type/vs2_out/final-viral-score.tsv
@@ -1,0 +1,9 @@
+seqname	dsDNAphage	ssDNA	max_score	max_score_group	length	hallmark	viral	cellular
+Caudo-circular||full	0.993	0.467	0.993	dsDNAphage	31746	4	77.8	0.0
+Caudo-linear||full	1.0	0.24	1.0	dsDNAphage	13841	12	85.7	0.0
+NCLDV-linear||full	0.833	0.067	0.833	dsDNAphage	1181111	9	53.7	5.3
+ssDNA-linear||full	0.8	0.927	0.927	ssDNA	4258	0	100.0	0.0
+RNA-linear||full	0.5	0.013	0.5	dsDNAphage	5538	0	20.0	0.0
+lavidaviridae-linear||full	0.993	0.667	0.993	dsDNAphage	8598	1	44.4	0.0
+Caudo-provirus||0_partial	0.893	0.0	0.893	dsDNAphage	38206	12	26.9	15.3
+Caudo-1hallmarkgene||lt2gene				dsDNAphage	606	1	100.0	0.0

--- a/q2_viromics/tests/test_format.py
+++ b/q2_viromics/tests/test_format.py
@@ -5,6 +5,9 @@
 #
 # The full license is in the file LICENSE, distributed with this software.
 # ----------------------------------------------------------------------------
+import os
+import tempfile
+
 from qiime2.plugin import ValidationError
 from qiime2.plugin.testing import TestPluginBase
 
@@ -24,6 +27,45 @@ from q2_viromics.types._format import (
 class TestVirsorter2OutFormats(TestPluginBase):
     package = "q2_viromics.tests"
 
+    def setUp(self):
+        # Set up temporary directory for testing
+        self.temp_dir = tempfile.TemporaryDirectory()
+
+    def tearDown(self):
+        # Clean up temporary directory
+        self.temp_dir.cleanup()
+
+    def _create_temp_file(self, content):
+        temp_file = os.path.join(self.temp_dir.name, "temp_file.tsv")
+        with open(temp_file, "w") as f:
+            f.write(content)
+        return temp_file
+
+    def test_error_reading_file(self):
+        # Create a malformed file that will cause an error when reading
+        temp_file = self._create_temp_file("not\ta\ttsv\ncontent")
+
+        with self.assertRaisesRegex(ValidationError, "ViralBoundaryFmt"):
+            format = ViralBoundaryFmt(temp_file, mode="r")
+            format.validate()
+
+    def test_file_is_empty(self):
+        # Create an empty file
+        temp_file = self._create_temp_file("")
+
+        with self.assertRaisesRegex(ValidationError, "ViralBoundaryFmt"):
+            format = ViralBoundaryFmt(temp_file, mode="r")
+            format.validate()
+
+    def test_header_mismatch(self):
+        # Create a file with incorrect headers
+        incorrect_headers = "wrong\theaders\tfor\ttest\n"
+        temp_file = self._create_temp_file(incorrect_headers)
+
+        with self.assertRaisesRegex(ValidationError, "ViralBoundaryFmt"):
+            format = ViralBoundaryFmt(temp_file, mode="r")
+            format.validate()
+
     def test_Virsorter2ViralBoundaryFormat(self):
         filepath = self.get_data_path("type/vs2_out/final-viral-boundary.tsv")
         format = ViralBoundaryFmt(filepath, mode="r")
@@ -33,6 +75,26 @@ class TestVirsorter2OutFormats(TestPluginBase):
         filepath = self.get_data_path("type/vs2_out/final-viral-score.tsv")
         format = ViralScoreFmt(filepath, mode="r")
         format.validate()
+
+    def test_validate_numeric_field_invalid_value(self):
+        # Create an instance of ViralBoundaryFmt
+        format = ViralBoundaryFmt(
+            self.get_data_path("type/vs2_out/final-viral-boundary.tsv"), mode="r"
+        )
+
+        # Invalid numeric value test case
+        value = "invalid_number"
+        line_number = 1
+        field_name = "length"
+        field_type = int
+
+        # Use self.assertRaisesRegex to check for the ValidationError
+        with self.assertRaisesRegex(
+            ValidationError,
+            f"Line {line_number}: '{field_name}' field should be a "
+            f"{field_type.__name__}, found '{value}'.",
+        ):
+            format._validate_numeric_field(value, line_number, field_name, field_type)
 
 
 class TestVirsorter2DbFormats(TestPluginBase):

--- a/q2_viromics/tests/test_format.py
+++ b/q2_viromics/tests/test_format.py
@@ -15,8 +15,24 @@ from q2_viromics.types._format import (
     HMMFormat,
     RbsCatetoryFormat,
     RbsCatetoryNotesFormat,
+    ViralBoundaryFmt,
+    ViralScoreFmt,
     Virsorter2DbDirFmt,
 )
+
+
+class TestVirsorter2OutFormats(TestPluginBase):
+    package = "q2_viromics.tests"
+
+    def test_Virsorter2ViralBoundaryFormat(self):
+        filepath = self.get_data_path("type/vs2_out/final-viral-boundary.tsv")
+        format = ViralBoundaryFmt(filepath, mode="r")
+        format.validate()
+
+    def test_Virsorter2ViralScoreFormat(self):
+        filepath = self.get_data_path("type/vs2_out/final-viral-score.tsv")
+        format = ViralScoreFmt(filepath, mode="r")
+        format.validate()
 
 
 class TestVirsorter2DbFormats(TestPluginBase):

--- a/q2_viromics/tests/test_transformers.py
+++ b/q2_viromics/tests/test_transformers.py
@@ -1,0 +1,70 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2024, Bokulich Lab.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file LICENSE, distributed with this software.
+# ----------------------------------------------------------------------------
+
+import os
+import unittest
+
+import pandas as pd
+from qiime2.plugin.testing import TestPluginBase
+
+from q2_viromics.types._format import ViralBoundaryDirFmt, ViralScoreDirFmt
+
+
+class TestTransformers(TestPluginBase):
+    package = "q2_viromics.tests"
+
+    def setUp(self):
+        super().setUp()
+
+    def tearDown(self):
+        # Clean up temporary directory
+        self.temp_dir.cleanup()
+
+    def test_dataframe_to_viral_score_dir_format(self):
+        df = pd.DataFrame({"col1": [1, 2], "col2": [3, 4]})
+        transformer = self.get_transformer(pd.DataFrame, ViralScoreDirFmt)
+        obs = transformer(df)
+        self.assertIsInstance(obs, ViralScoreDirFmt)
+        transformed_df = pd.read_csv(
+            os.path.join(str(obs), "final-viral-score.tsv"), sep="\t"
+        )
+        pd.testing.assert_frame_equal(df, transformed_df)
+
+    def test_viral_score_dir_format_to_dataframe(self):
+        df = pd.DataFrame({"col1": [1, 2], "col2": [3, 4]})
+        ff = ViralScoreDirFmt()
+        df.to_csv(os.path.join(str(ff), "final-viral-score.tsv"), sep="\t", index=False)
+        transformer = self.get_transformer(ViralScoreDirFmt, pd.DataFrame)
+        obs = transformer(ff)
+        self.assertIsInstance(obs, pd.DataFrame)
+        pd.testing.assert_frame_equal(df, obs)
+
+    def test_dataframe_to_viral_boundary_dir_format(self):
+        df = pd.DataFrame({"col1": [1, 2], "col2": [3, 4]})
+        transformer = self.get_transformer(pd.DataFrame, ViralBoundaryDirFmt)
+        obs = transformer(df)
+        self.assertIsInstance(obs, ViralBoundaryDirFmt)
+        transformed_df = pd.read_csv(
+            os.path.join(str(obs), "final-viral-boundary.tsv"), sep="\t"
+        )
+        pd.testing.assert_frame_equal(df, transformed_df)
+
+    def test_viral_boundary_dir_format_to_dataframe(self):
+        df = pd.DataFrame({"col1": [1, 2], "col2": [3, 4]})
+        ff = ViralBoundaryDirFmt()
+        df.to_csv(
+            os.path.join(str(ff), "final-viral-boundary.tsv"), sep="\t", index=False
+        )
+        transformer = self.get_transformer(ViralBoundaryDirFmt, pd.DataFrame)
+        obs = transformer(ff)
+        self.assertIsInstance(obs, pd.DataFrame)
+        pd.testing.assert_frame_equal(df, obs)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/q2_viromics/tests/test_transformers.py
+++ b/q2_viromics/tests/test_transformers.py
@@ -20,50 +20,49 @@ class TestTransformers(TestPluginBase):
 
     def setUp(self):
         super().setUp()
+        self.df = pd.DataFrame({"col1": [1, 2], "col2": [3, 4]})
 
     def tearDown(self):
         # Clean up temporary directory
         self.temp_dir.cleanup()
 
     def test_dataframe_to_viral_score_dir_format(self):
-        df = pd.DataFrame({"col1": [1, 2], "col2": [3, 4]})
         transformer = self.get_transformer(pd.DataFrame, ViralScoreDirFmt)
-        obs = transformer(df)
+        obs = transformer(self.df)
         self.assertIsInstance(obs, ViralScoreDirFmt)
         transformed_df = pd.read_csv(
             os.path.join(str(obs), "final-viral-score.tsv"), sep="\t"
         )
-        pd.testing.assert_frame_equal(df, transformed_df)
+        pd.testing.assert_frame_equal(self.df, transformed_df)
 
     def test_viral_score_dir_format_to_dataframe(self):
-        df = pd.DataFrame({"col1": [1, 2], "col2": [3, 4]})
         ff = ViralScoreDirFmt()
-        df.to_csv(os.path.join(str(ff), "final-viral-score.tsv"), sep="\t", index=False)
+        self.df.to_csv(
+            os.path.join(str(ff), "final-viral-score.tsv"), sep="\t", index=False
+        )
         transformer = self.get_transformer(ViralScoreDirFmt, pd.DataFrame)
         obs = transformer(ff)
         self.assertIsInstance(obs, pd.DataFrame)
-        pd.testing.assert_frame_equal(df, obs)
+        pd.testing.assert_frame_equal(self.df, obs)
 
     def test_dataframe_to_viral_boundary_dir_format(self):
-        df = pd.DataFrame({"col1": [1, 2], "col2": [3, 4]})
         transformer = self.get_transformer(pd.DataFrame, ViralBoundaryDirFmt)
-        obs = transformer(df)
+        obs = transformer(self.df)
         self.assertIsInstance(obs, ViralBoundaryDirFmt)
         transformed_df = pd.read_csv(
             os.path.join(str(obs), "final-viral-boundary.tsv"), sep="\t"
         )
-        pd.testing.assert_frame_equal(df, transformed_df)
+        pd.testing.assert_frame_equal(self.df, transformed_df)
 
     def test_viral_boundary_dir_format_to_dataframe(self):
-        df = pd.DataFrame({"col1": [1, 2], "col2": [3, 4]})
         ff = ViralBoundaryDirFmt()
-        df.to_csv(
+        self.df.to_csv(
             os.path.join(str(ff), "final-viral-boundary.tsv"), sep="\t", index=False
         )
         transformer = self.get_transformer(ViralBoundaryDirFmt, pd.DataFrame)
         obs = transformer(ff)
         self.assertIsInstance(obs, pd.DataFrame)
-        pd.testing.assert_frame_equal(df, obs)
+        pd.testing.assert_frame_equal(self.df, obs)
 
 
 if __name__ == "__main__":

--- a/q2_viromics/tests/test_virsorter2_run.py
+++ b/q2_viromics/tests/test_virsorter2_run.py
@@ -1,0 +1,161 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2024, Bokulich Lab.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file LICENSE, distributed with this software.
+# ----------------------------------------------------------------------------
+
+
+import subprocess
+import unittest
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+
+from q2_viromics.virsorter2_run import (
+    _virsorter2_analysis,
+    virsorter2_run,
+    vs2_run_execution,
+)
+
+
+class TestVirsorter2Analysis(unittest.TestCase):
+    @patch("q2_viromics.virsorter2_run.run_command")
+    @patch("q2_viromics.virsorter2_run.DNAFASTAFormat")
+    @patch("q2_viromics.virsorter2_run.Virsorter2DbDirFmt")
+    def test_vs2_run_execution_success(
+        self, mock_Virsorter2DbDirFmt, mock_DNAFASTAFormat, mock_run_command
+    ):
+        # Mock the paths
+        mock_tmp = "/fake/tmp"
+        mock_sequences = MagicMock()
+        mock_sequences.path = "/fake/sequences"
+        mock_database = MagicMock()
+        mock_database.path = "/fake/database"
+
+        # Call the function
+        vs2_run_execution(mock_tmp, mock_sequences, mock_database, n_jobs=5)
+
+        # Expected command
+        expected_cmd = [
+            "virsorter",
+            "run",
+            "-w",
+            mock_tmp,
+            "-d",
+            mock_database.path,
+            "-i",
+            mock_sequences.path,
+            "-j",
+            "5",
+            "--use-conda-off",
+        ]
+
+        # Assert the command was called
+        mock_run_command.assert_called_once_with(expected_cmd)
+
+    @patch(
+        "q2_viromics.virsorter2_run.run_command",
+        side_effect=subprocess.CalledProcessError(1, "cmd"),
+    )
+    def test_vs2_run_execution_failure(self, mock_run_command):
+        # Mock the paths
+        mock_tmp = "/fake/tmp"
+        mock_sequences = MagicMock()
+        mock_sequences.path = "/fake/sequences"
+        mock_database = MagicMock()
+        mock_database.path = "/fake/database"
+
+        # Call the function and assert it raises an Exception
+        with self.assertRaises(Exception) as context:
+            vs2_run_execution(mock_tmp, mock_sequences, mock_database, n_jobs=5)
+
+        self.assertTrue(
+            "An error was encountered while running virsorter2 run"
+            in str(context.exception)
+        )
+
+    @patch("q2_viromics.virsorter2_run.vs2_run_execution")
+    @patch("q2_viromics.virsorter2_run.DNAFASTAFormat")
+    @patch("q2_viromics.virsorter2_run.pd.read_csv")
+    @patch("shutil.copy")
+    @patch("tempfile.TemporaryDirectory")
+    def test_virsorter2_analysis_success(
+        self,
+        mock_tempdir,
+        mock_shutil_copy,
+        mock_read_csv,
+        mock_DNAFASTAFormat,
+        mock_vs2_run_execution,
+    ):
+        # Mock the context managers
+        mock_tempdir.return_value.__enter__.return_value = "/fake/tmp"
+
+        # Mock the data frames
+        mock_viral_score_df = pd.DataFrame({"mock": ["data"]})
+        mock_viral_boundary_df = pd.DataFrame({"mock": ["data"]})
+        mock_read_csv.side_effect = [mock_viral_score_df, mock_viral_boundary_df]
+
+        # Mock the sequences and database
+        mock_sequences = MagicMock()
+        mock_sequences.path = "/fake/sequences"
+        mock_database = MagicMock()
+        mock_database.path = "/fake/database"
+
+        # Call the function
+        result = _virsorter2_analysis(mock_sequences, mock_database, n_jobs=5)
+
+        # Assertions
+        mock_vs2_run_execution.assert_called_once_with(
+            "/fake/tmp", mock_sequences, mock_database, 5
+        )
+        mock_shutil_copy.assert_called_once_with(
+            "/fake/tmp/final-viral-combined.fa", str(result[0])
+        )
+        mock_read_csv.assert_any_call("/fake/tmp/final-viral-score.tsv", sep="\t")
+        mock_read_csv.assert_any_call("/fake/tmp/final-viral-boundary.tsv", sep="\t")
+
+        self.assertEqual(result[1].equals(mock_viral_score_df), True)
+        self.assertEqual(result[2].equals(mock_viral_boundary_df), True)
+
+    @patch("q2_viromics.virsorter2_run._virsorter2_analysis")
+    @patch("q2_viromics.virsorter2_run.Virsorter2DbDirFmt")
+    @patch("q2_viromics.virsorter2_run.DNAFASTAFormat")
+    def test_virsorter2_run(
+        self, mock_DNAFASTAFormat, mock_Virsorter2DbDirFmt, mock_virsorter2_analysis
+    ):
+        # Mock the context
+        mock_ctx = MagicMock()
+        mock_ctx.get_action.return_value = mock_virsorter2_analysis
+
+        # Mock the analysis result
+        mock_viral_sequences = MagicMock()
+        mock_viral_score_df = pd.DataFrame({"mock": ["data"]})
+        mock_viral_boundary_df = pd.DataFrame({"mock": ["data"]})
+        mock_virsorter2_analysis.return_value = (
+            mock_viral_sequences,
+            mock_viral_score_df,
+            mock_viral_boundary_df,
+        )
+
+        # Mock the sequences and database
+        mock_sequences = MagicMock()
+        mock_sequences.path = "/fake/sequences"
+        mock_database = MagicMock()
+        mock_database.path = "/fake/database"
+
+        # Call the function
+        result = virsorter2_run(mock_ctx, mock_sequences, mock_database, n_jobs=5)
+
+        # Assertions
+        mock_virsorter2_analysis.assert_called_once_with(
+            sequences=mock_sequences, database=mock_database, n_jobs=5
+        )
+        self.assertEqual(result[0], mock_viral_sequences)
+        self.assertTrue(result[1].equals(mock_viral_score_df))
+        self.assertTrue(result[2].equals(mock_viral_boundary_df))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/q2_viromics/types/__init__.py
+++ b/q2_viromics/types/__init__.py
@@ -5,3 +5,35 @@
 #
 # The full license is in the file LICENSE, distributed with this software.
 # ----------------------------------------------------------------------------
+from ._format import (
+    GeneralBinaryFileFormat,
+    GeneralTSVFormat,
+    HallmarkGeneListFormat,
+    HMMFormat,
+    RbsCatetoryFormat,
+    RbsCatetoryNotesFormat,
+    ViralBoundaryDirFmt,
+    ViralBoundaryFmt,
+    ViralScoreDirFmt,
+    ViralScoreFmt,
+    Virsorter2DbDirFmt,
+)
+from ._type import ViralBoundary, ViralScore, Virsorter2Db
+
+__all__ = [
+    "Virsorter2Db",
+    "ViralScore",
+    "ViralScoreFmt",
+    "Virsorter2DbDirFmt",
+    "HMMFormat",
+    "GeneralBinaryFileFormat",
+    "HallmarkGeneListFormat",
+    "RbsCatetoryNotesFormat",
+    "RbsCatetoryFormat",
+    "GeneralTSVFormat",
+    "ViralScoreDirFmt",
+    "ViralScoreFmt",
+    "ViralBoundaryDirFmt",
+    "ViralBoundaryFmt",
+    "ViralBoundary",
+]

--- a/q2_viromics/types/_format.py
+++ b/q2_viromics/types/_format.py
@@ -393,15 +393,3 @@ class Virsorter2DbDirFmt(model.DirectoryFormat):
     @db_files.set_path_maker
     def db_files_path_maker(self, sample_id):
         return "group/{}/{}.db".format(sample_id[0], sample_id[1])
-
-
-ViralScoreFmt
-Virsorter2DbDirFmt
-HMMFormat
-GeneralBinaryFileFormat
-HallmarkGeneListFormat
-RbsCatetoryNotesFormat
-RbsCatetoryFormat
-GeneralTSVFormat
-ViralScoreDirFmt
-ViralScoreFmt

--- a/q2_viromics/types/_transformer.py
+++ b/q2_viromics/types/_transformer.py
@@ -1,0 +1,42 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2024, Bokulich Lab.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file LICENSE, distributed with this software.
+# ----------------------------------------------------------------------------
+import os
+
+import pandas as pd
+
+from q2_viromics.types._format import ViralBoundaryDirFmt, ViralScoreDirFmt
+
+from ..plugin_setup import plugin
+
+
+@plugin.register_transformer
+def _1(data: pd.DataFrame) -> ViralScoreDirFmt:
+    ff = ViralScoreDirFmt()
+    ViralScore_file_path = os.path.join(str(ff), "final-viral-score.tsv")
+    data.to_csv(ViralScore_file_path, sep="\t", index=False)
+    return ff
+
+
+@plugin.register_transformer
+def _2(data: ViralScoreDirFmt) -> pd.DataFrame:
+    file = pd.read_csv(os.path.join(str(data), "final-viral-score.tsv"), sep="\t")
+    return file
+
+
+@plugin.register_transformer
+def _3(data: pd.DataFrame) -> ViralBoundaryDirFmt:
+    ff = ViralBoundaryDirFmt()
+    ViralScore_file_path = os.path.join(str(ff), "final-viral-boundary.tsv")
+    data.to_csv(ViralScore_file_path, sep="\t", index=False)
+    return ff
+
+
+@plugin.register_transformer
+def _4(data: ViralBoundaryDirFmt) -> pd.DataFrame:
+    file = pd.read_csv(os.path.join(str(data), "final-viral-boundary.tsv"), sep="\t")
+    return file

--- a/q2_viromics/types/_transformer.py
+++ b/q2_viromics/types/_transformer.py
@@ -17,8 +17,7 @@ from ..plugin_setup import plugin
 @plugin.register_transformer
 def _1(data: pd.DataFrame) -> ViralScoreDirFmt:
     ff = ViralScoreDirFmt()
-    ViralScore_file_path = os.path.join(str(ff), "final-viral-score.tsv")
-    data.to_csv(ViralScore_file_path, sep="\t", index=False)
+    data.to_csv(os.path.join(str(ff), "final-viral-score.tsv"), sep="\t", index=False)
     return ff
 
 
@@ -31,8 +30,9 @@ def _2(data: ViralScoreDirFmt) -> pd.DataFrame:
 @plugin.register_transformer
 def _3(data: pd.DataFrame) -> ViralBoundaryDirFmt:
     ff = ViralBoundaryDirFmt()
-    ViralScore_file_path = os.path.join(str(ff), "final-viral-boundary.tsv")
-    data.to_csv(ViralScore_file_path, sep="\t", index=False)
+    data.to_csv(
+        os.path.join(str(ff), "final-viral-boundary.tsv"), sep="\t", index=False
+    )
     return ff
 
 

--- a/q2_viromics/types/_type.py
+++ b/q2_viromics/types/_type.py
@@ -5,7 +5,9 @@
 #
 # The full license is in the file LICENSE, distributed with this software.
 # ----------------------------------------------------------------------------
-
+from q2_types.feature_data import FeatureData
 from qiime2.plugin import SemanticType
 
 Virsorter2Db = SemanticType("Virsorter2Db")
+ViralScore = SemanticType("ViralScore", variant_of=FeatureData.field["type"])
+ViralBoundary = SemanticType("ViralBoundary", variant_of=FeatureData.field["type"])

--- a/q2_viromics/virsorter2_run.py
+++ b/q2_viromics/virsorter2_run.py
@@ -52,16 +52,24 @@ def _virsorter2_analysis(
     viral_sequences = DNAFASTAFormat()
 
     with tempfile.TemporaryDirectory() as tmp:
+        # Execute the "virsorter2 run" command
         vs2_run_execution(tmp, sequences, database, n_jobs)
 
-        viral_combined_path = os.path.join(tmp, "final-viral-combined.fa")
-        shutil.copy(viral_combined_path, os.path.join(str(viral_sequences)))
+        # Copy the combined viral sequences file
+        shutil.copy(
+            os.path.join(tmp, "final-viral-combined.fa"),
+            os.path.join(str(viral_sequences)),
+        )
 
-        viral_score_fp = os.path.join(tmp, "final-viral-score.tsv")
-        viral_score_df = pd.read_csv(viral_score_fp, sep="\t")
+        # Read the viral score file into a DataFrame
+        viral_score_df = pd.read_csv(
+            os.path.join(tmp, "final-viral-score.tsv"), sep="\t"
+        )
 
-        viral_boundary_fp = os.path.join(tmp, "final-viral-boundary.tsv")
-        viral_boundary_df = pd.read_csv(viral_boundary_fp, sep="\t")
+        # Read the viral boundary file into a DataFrame
+        viral_boundary_df = pd.read_csv(
+            os.path.join(tmp, "final-viral-boundary.tsv"), sep="\t"
+        )
 
     return (viral_sequences, viral_score_df, viral_boundary_df)
 

--- a/q2_viromics/virsorter2_run.py
+++ b/q2_viromics/virsorter2_run.py
@@ -1,0 +1,80 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2024, Bokulich Lab.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file LICENSE, distributed with this software.
+# ----------------------------------------------------------------------------
+import os
+import shutil
+import subprocess
+import tempfile
+
+import pandas as pd
+from q2_types.feature_data import DNAFASTAFormat
+
+from q2_viromics._utils import run_command
+from q2_viromics.types._format import Virsorter2DbDirFmt
+
+
+# Create the command to fetch the Virsorter2 database
+def vs2_run_execution(tmp, sequences, database, n_jobs):
+    cmd = [
+        "virsorter",
+        "run",
+        "-w",
+        str(tmp),
+        "-d",
+        str(database.path),
+        "-i",
+        str(sequences.path),
+        "-j",
+        str(n_jobs),
+        "--use-conda-off",
+    ]
+
+    try:
+        run_command(cmd)
+    except subprocess.CalledProcessError as e:
+        raise Exception(
+            "An error was encountered while running virsorter2 run, "
+            f"(return code {e.returncode}), please inspect "
+            "stdout and stderr to learn more."
+        )
+
+
+def _virsorter2_analysis(
+    sequences: DNAFASTAFormat,
+    database: Virsorter2DbDirFmt,
+    n_jobs: int = 10,
+) -> (DNAFASTAFormat, pd.DataFrame, pd.DataFrame):
+
+    viral_sequences = DNAFASTAFormat()
+
+    with tempfile.TemporaryDirectory() as tmp:
+        vs2_run_execution(tmp, sequences, database, n_jobs)
+
+        viral_combined_path = os.path.join(tmp, "final-viral-combined.fa")
+        shutil.copy(viral_combined_path, os.path.join(str(viral_sequences)))
+
+        viral_score_fp = os.path.join(tmp, "final-viral-score.tsv")
+        viral_score_df = pd.read_csv(viral_score_fp, sep="\t")
+
+        viral_boundary_fp = os.path.join(tmp, "final-viral-boundary.tsv")
+        viral_boundary_df = pd.read_csv(viral_boundary_fp, sep="\t")
+
+    return (viral_sequences, viral_score_df, viral_boundary_df)
+
+
+def virsorter2_run(
+    ctx,
+    sequences,
+    database,
+    n_jobs=10,
+):
+    vs2_analysis = ctx.get_action("viromics", "_virsorter2_analysis")
+    (viral_sequences, viral_score_table, viral_boundary_table) = vs2_analysis(
+        sequences=sequences, database=database, n_jobs=n_jobs
+    )
+
+    return viral_sequences, viral_score_table, viral_boundary_table


### PR DESCRIPTION
This PR closes #5 .

- Adds _virsorter2_analysis action which executes virsorter2 main function for viral identification
- Adds a pipeline virsorter2_run which uses _virsorter2_analysis. In a following PR another action will use the tables created by _virsorter2_analysis to create a visualization.

### Set up the environment
```shell
mamba create -n q2-viromics2 -c conda-forge -c bioconda -c https://packages.qiime2.org/qiime2/2023.5/core/passed/  -c defaults q2-types numpy=1.23.5 q2cli virsorter=2 "python=3.8" scikit-learn=0.22.1 pandas seaborn hmmer==3.3 prodigal=2.6 screed=1 ruamel.yaml click pip last ncbi-genome-download checkv pyhmmer
```

###  Activate q2-viromics environment
```shell
conda activate q2-viromics
```

### Clone the repo and checkout the PR branch
```bash
git clone https://github.com/bokulich-lab/q2-viromics.git
cd q2-viromics
git fetch origin pull/6/head:pr-6
git checkout pr-6
pip install -e .
```

### Test
#### Download the input [datasets](https://polybox.ethz.ch/index.php/s/zjiyGywgMjLnD7y)
```bash
qiime viromics virsorter2-analysis --i-sequences input.qza --i-database db.qza  --output-dir outDir --verbose
```
